### PR TITLE
onTouchEnd function was setting wrong state via setState- CHANGED, in…

### DIFF
--- a/src/org/gestouch/gestures/TransformGesture.as
+++ b/src/org/gestouch/gestures/TransformGesture.as
@@ -175,7 +175,7 @@ package org.gestouch.gestures
 				if (state == GestureState.BEGAN || state == GestureState.CHANGED)
 				{
 					updateLocation();
-					setState(GestureState.CHANGED);
+					setState(GestureState.ENDED);
 				}
 			}
 		}


### PR DESCRIPTION
Hi,

Great Project, by the way :+1: 
Had a bug where 
onTouchEnd function was setting wrong state via setState- CHANGED, instead of ENDED,
thus ENDED listener was never evoked for GestureEvent.ENDED, 
when there is at least one active touch event. (only CHANGED was evoked, as expected in the code)
## side effects

I'm not very familiar with this framework, but perhaps 
it affects ended events sent when multitouch is used?

for me it works now, both for singe touch point,
and when two touch points are being active, 
for  instance when rotating an image, so i did not experience
any side effects yet.

Tested on AIR for Windows and for Mobile Android (sdk version 18)
using normal displaylist instances (not starling)
